### PR TITLE
Add a toolbar to the entire page layout

### DIFF
--- a/config/index.tsx
+++ b/config/index.tsx
@@ -1,5 +1,5 @@
-import { developmentConfig } from './development';
-import { productionConfig } from './production';
+import { developmentConfig } from 'config/development';
+import { productionConfig } from 'config/production';
 
 interface Configuration {
   /**

--- a/paths.js
+++ b/paths.js
@@ -3,7 +3,6 @@ const root = __dirname;
 const src = join(root, 'src');
 const view = join(src, 'view');
 const model = join(src, 'model');
-const basic = join(view, 'basic');
 const styles = join(src, 'styles');
 const state = join(src, 'state');
 const client = join(src, 'client');
@@ -15,7 +14,6 @@ module.exports = {
   src,
   view,
   model,
-  basic,
   styles,
   state,
   client,

--- a/src/state/NavigationState.tsx
+++ b/src/state/NavigationState.tsx
@@ -11,12 +11,10 @@ class BasicNavigationState {
   @action
   public openDrawer(): void {
     this.drawerOpen = true;
-    console.log(this.drawerOpen);
   }
   @action
   public closeDrawer(): void {
     this.drawerOpen = false;
-    console.log(this.drawerOpen);
   }
 }
 

--- a/src/state/NavigationState.tsx
+++ b/src/state/NavigationState.tsx
@@ -1,0 +1,23 @@
+import { observable, computed, action } from 'mobx';
+
+export interface NavigationState {
+  drawerOpen: boolean;
+  openDrawer: () => void;
+  closeDrawer: () => void;
+}
+
+class BasicNavigationState {
+  @observable public drawerOpen: boolean = false;
+  @action
+  public openDrawer(): void {
+    this.drawerOpen = true;
+    console.log(this.drawerOpen);
+  }
+  @action
+  public closeDrawer(): void {
+    this.drawerOpen = false;
+    console.log(this.drawerOpen);
+  }
+}
+
+export const state: NavigationState = new BasicNavigationState();

--- a/src/view/NavigationMenu.tsx
+++ b/src/view/NavigationMenu.tsx
@@ -14,7 +14,7 @@ import { createStyled } from 'view/createStyled';
 export const drawerWidth = 192;
 
 const Styled = createStyled(theme => ({
-  toolbar: {
+  drawerCloser: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
@@ -69,7 +69,7 @@ export const NavigationMenu: SFC<{}> = () => (
                 }}
                 open={navigationState.drawerOpen}
               >
-                <div className={classes.toolbar}>
+                <div className={classes.drawerCloser}>
                   <IconButton
                     aria-label="Close Drawer"
                     onClick={() => navigationState.closeDrawer()}

--- a/src/view/NavigationMenu.tsx
+++ b/src/view/NavigationMenu.tsx
@@ -1,9 +1,8 @@
 import React, { SFC } from 'react';
 import { Route } from 'react-router-dom';
 import { Observer } from 'mobx-react';
-import { ListItem, ListItemIcon, ListItemText } from 'material-ui';
 import Divider from 'material-ui/Divider';
-import List from 'material-ui/List';
+import List, { ListItem, ListItemIcon, ListItemText } from 'material-ui/List';
 import * as Icons from '@material-ui/icons';
 import { state as profileState } from 'state/ProfileState';
 import { state as navigationState } from 'state/NavigationState';

--- a/src/view/NavigationMenu.tsx
+++ b/src/view/NavigationMenu.tsx
@@ -1,11 +1,47 @@
 import React, { SFC } from 'react';
 import { Route } from 'react-router-dom';
 import { Observer } from 'mobx-react';
+import classNames from 'classnames';
 import Divider from 'material-ui/Divider';
+import Drawer from 'material-ui/Drawer';
+import IconButton from 'material-ui/IconButton';
 import List, { ListItem, ListItemIcon, ListItemText } from 'material-ui/List';
 import * as Icons from '@material-ui/icons';
 import { state as profileState } from 'state/ProfileState';
 import { state as navigationState } from 'state/NavigationState';
+import { createStyled } from 'view/createStyled';
+
+export const drawerWidth = 192;
+
+const Styled = createStyled(theme => ({
+  toolbar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    paddingLeft: theme.spacing.unit,
+    paddingRight: theme.spacing.unit,
+    ...theme.mixins.toolbar
+  },
+  navPaper: {
+    position: 'relative',
+    overflowX: 'hidden',
+    width: drawerWidth,
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen
+    })
+  },
+  navPaperClosed: {
+    width: theme.spacing.unit * 7,
+    [theme.breakpoints.up('sm')]: {
+      width: theme.spacing.unit * 9
+    },
+    transition: theme.transitions.create('width', {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen
+    })
+  }
+}));
 
 const NavigationButton = ({ icon, primary, ...other }) => (
   <ListItem button {...other}>
@@ -15,33 +51,55 @@ const NavigationButton = ({ icon, primary, ...other }) => (
 );
 
 export const NavigationMenu: SFC<{}> = () => (
-  <Route
-    render={({ history }) => (
-      /* TODO: Unfortunately, render callbacks aren't considered with MobX's observer so we have to
-       * use the <Observer> syntax. There might be a better way. */
-      <Observer>
-        {() => (
-          <div>
-            <List component="nav">
-              <NavigationButton
-                onClick={() => history.push('/')}
-                icon={<Icons.Dashboard />}
-                primary="Overview"
-              />
-              <NavigationButton
-                onClick={() => history.push(`/profiles/${profileState.me.id}`)}
-                icon={<Icons.AccountCircle />}
-                primary="Account"
-              />
-              <NavigationButton
-                onClick={() => history.push('/settings')}
-                icon={<Icons.Settings />}
-                primary="Settings"
-              />
-            </List>
-          </div>
+  <Styled>
+    {({ classes }) => (
+      <Route
+        render={({ history }) => (
+          /* TODO: Unfortunately, render callbacks aren't considered with MobX's observer so we have to
+          * use the <Observer> syntax. There might be a better way. */
+          <Observer>
+            {() => (
+              <Drawer
+                variant="permanent"
+                classes={{
+                  paper: classNames(
+                    classes.navPaper,
+                    !navigationState.drawerOpen && classes.navPaperClosed
+                  )
+                }}
+                open={navigationState.drawerOpen}
+              >
+                <div className={classes.toolbar}>
+                  <IconButton
+                    aria-label="Close Drawer"
+                    onClick={() => navigationState.closeDrawer()}
+                  >
+                    <Icons.ChevronLeft />
+                  </IconButton>
+                </div>
+                <Divider />
+                <List component="nav">
+                  <NavigationButton
+                    onClick={() => history.push('/')}
+                    icon={<Icons.Dashboard />}
+                    primary="Overview"
+                  />
+                  <NavigationButton
+                    onClick={() => history.push(`/profiles/${profileState.me.id}`)}
+                    icon={<Icons.AccountCircle />}
+                    primary="Account"
+                  />
+                  <NavigationButton
+                    onClick={() => history.push('/settings')}
+                    icon={<Icons.Settings />}
+                    primary="Settings"
+                  />
+                </List>
+              </Drawer>
+            )}
+          </Observer>
         )}
-      </Observer>
+      />
     )}
-  />
+  </Styled>
 );

--- a/src/view/NavigationMenu.tsx
+++ b/src/view/NavigationMenu.tsx
@@ -1,105 +1,48 @@
 import React, { SFC } from 'react';
-import Drawer from 'material-ui/Drawer';
-import * as Icons from '@material-ui/icons';
-import { List, ListItem, ListItemIcon, ListItemText } from 'material-ui';
-import { state as profileState } from 'state/ProfileState';
 import { Route } from 'react-router-dom';
-import { observable, action, autorun, computed } from 'mobx';
-import { observer, Observer } from 'mobx-react';
-import { createStyled } from 'view/createStyled';
+import { Observer } from 'mobx-react';
+import { ListItem, ListItemIcon, ListItemText } from 'material-ui';
 import Divider from 'material-ui/Divider';
-import classNames from 'classnames';
-// TODO: Maybe come back to this and see if we can get proper type validation going
-const Styled: any = createStyled(theme => ({
-  navPaper: {
-    overflowX: 'hidden',
-    position: 'relative'
-  },
-  navPaperClosed: {
-    width: theme.spacing.unit * 7,
-    [theme.breakpoints.up('sm')]: {
-      width: theme.spacing.unit * 9
-    },
-    transition: theme.transitions.create(['margin', 'width'], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen
-    })
-  },
-  navPaperOpen: {
-    width: theme.spacing.unit * 24,
-    transition: theme.transitions.create(['margin', 'width'], {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen
-    })
-  }
-}));
-export interface NavigationMenuProps {}
-// TODO: In this case, it would probably be better if we didn't use the same state for all NavigationMenu components
-class NavigationState {
-  @observable public open: boolean = false;
-  @computed
-  public get actionName(): string {
-    return this.open ? 'Close' : 'Open';
-  }
-  @action
-  public toggleOpen(): void {
-    this.open = !this.open;
-  }
-}
-const navState = new NavigationState();
+import List from 'material-ui/List';
+import * as Icons from '@material-ui/icons';
+import { state as profileState } from 'state/ProfileState';
+import { state as navigationState } from 'state/NavigationState';
+
 const NavigationButton = ({ icon, primary, ...other }) => (
   <ListItem button {...other}>
     <ListItemIcon>{icon}</ListItemIcon>
     <ListItemText primary={primary} />
   </ListItem>
 );
-export const NavigationMenu: SFC<NavigationMenuProps> = () => (
-  <Styled>
-    {({ classes }) => (
-      <Route
-        render={({ history }) => (
-          /* TODO: Unfortunately, render callbacks aren't considered with MobX's observer so we have to use the <Observer> syntax. 
-            There might be a better way. */
-          <Observer>
-            {() => (
-              <Drawer
-                variant="permanent"
-                classes={{
-                  paper: classNames(
-                    classes.navPaper,
-                    navState.open ? classes.navPaperOpen : classes.navPaperClosed
-                  )
-                }}
-                open={navState.open}
-              >
-                <List component="nav">
-                  <NavigationButton
-                    onClick={() => navState.toggleOpen()}
-                    icon={navState.open ? <Icons.ChevronLeft /> : <Icons.ChevronRight />}
-                    primary={navState.actionName}
-                  />
-                  <Divider />
-                  <NavigationButton
-                    onClick={() => history.push('/')}
-                    icon={<Icons.Dashboard />}
-                    primary="Overview"
-                  />
-                  <NavigationButton
-                    onClick={() => history.push(`/profiles/${profileState.me.id}`)}
-                    icon={<Icons.AccountCircle />}
-                    primary="Account"
-                  />
-                  <NavigationButton
-                    onClick={() => history.push('/settings')}
-                    icon={<Icons.Settings />}
-                    primary="Settings"
-                  />
-                </List>
-              </Drawer>
-            )}
-          </Observer>
+
+export const NavigationMenu: SFC<{}> = () => (
+  <Route
+    render={({ history }) => (
+      /* TODO: Unfortunately, render callbacks aren't considered with MobX's observer so we have to
+       * use the <Observer> syntax. There might be a better way. */
+      <Observer>
+        {() => (
+          <div>
+            <List component="nav">
+              <NavigationButton
+                onClick={() => history.push('/')}
+                icon={<Icons.Dashboard />}
+                primary="Overview"
+              />
+              <NavigationButton
+                onClick={() => history.push(`/profiles/${profileState.me.id}`)}
+                icon={<Icons.AccountCircle />}
+                primary="Account"
+              />
+              <NavigationButton
+                onClick={() => history.push('/settings')}
+                icon={<Icons.Settings />}
+                primary="Settings"
+              />
+            </List>
+          </div>
         )}
-      />
+      </Observer>
     )}
-  </Styled>
+  />
 );

--- a/src/view/Overview.tsx
+++ b/src/view/Overview.tsx
@@ -1,9 +1,9 @@
 import React, { SFC } from 'react';
 import { observer } from 'mobx-react';
 import Typography from 'material-ui/Typography';
-import { SpecificationList } from 'basic/SpecificationList';
 import { state } from 'state/SpecificationState';
-import { ContentContainer } from 'basic/ContentContainer';
+import { ContentContainer } from 'view/basic/ContentContainer';
+import { SpecificationList } from 'view/basic/SpecificationList';
 
 /**
  * An overview of the current state of Swagger Platform.

--- a/src/view/Overview.tsx
+++ b/src/view/Overview.tsx
@@ -1,8 +1,10 @@
 import React, { SFC } from 'react';
-import { SpecificationList } from 'basic/SpecificationList';
 import { observer } from 'mobx-react';
+import Typography from 'material-ui/Typography';
+import { SpecificationList } from 'basic/SpecificationList';
 import { state } from 'state/SpecificationState';
 import { ContentContainer } from 'basic/ContentContainer';
+
 /**
  * An overview of the current state of Swagger Platform.
  * Includes, for example, a list of all the specications registered on the platform.
@@ -21,3 +23,11 @@ export const Overview: SFC<{}> = observer(({ history }) => (
     />
   </ContentContainer>
 ));
+
+export const OverviewToolbar: SFC<{}> = () => (
+  <div>
+    <Typography color="inherit" variant="title">
+      Overview
+    </Typography>
+  </div>
+);

--- a/src/view/Page.tsx
+++ b/src/view/Page.tsx
@@ -41,11 +41,6 @@ const Styled = createStyled(theme => ({
     })
   },
   toolbar: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    paddingLeft: theme.spacing.unit,
-    paddingRight: theme.spacing.unit,
     ...theme.mixins.toolbar
   },
   menuButton: {

--- a/src/view/Page.tsx
+++ b/src/view/Page.tsx
@@ -40,7 +40,7 @@ const Styled = createStyled(theme => ({
       duration: theme.transitions.duration.enteringScreen
     })
   },
-  toolbar: {
+  toolbarSpacing: {
     ...theme.mixins.toolbar
   },
   menuButton: {
@@ -125,7 +125,7 @@ export const Page: ComponentType<{}> = () => (
               <NavigationMenu />
             </nav>
             <main className={classes.content}>
-              <div className={classes.toolbar} />
+              <div className={classes.toolbarSpacing} />
               <Switch>
                 {routes.map(({ path, component, exact }, i) => (
                   <Route key={i} path={path} exact={exact} component={component} />

--- a/src/view/Page.tsx
+++ b/src/view/Page.tsx
@@ -78,10 +78,6 @@ const Styled = createStyled(theme => {
       paddingRight: theme.spacing.unit,
       ...theme.mixins.toolbar
     },
-    sideBar: {
-      flexGrow: 0,
-      flexShrink: 0
-    },
     content: {
       flexBasis: '600px',
       flexGrow: 1,
@@ -154,31 +150,29 @@ export const Page: ComponentType<{}> = () => (
                 </Switch>
               </Toolbar>
             </AppBar>
-            <aside className={classes.sideBar}>
-              <nav>
-                <Drawer
-                  variant="permanent"
-                  classes={{
-                    paper: classNames(
-                      classes.navPaper,
-                      !navigationState.drawerOpen && classes.navPaperClosed
-                    )
-                  }}
-                  open={navigationState.drawerOpen}
-                >
-                  <div className={classes.toolbar}>
-                    <IconButton
-                      aria-label="Close Drawer"
-                      onClick={() => navigationState.closeDrawer()}
-                    >
-                      <Icons.ChevronLeft />
-                    </IconButton>
-                  </div>
-                  <Divider />
-                  <NavigationMenu />
-                </Drawer>
-              </nav>
-            </aside>
+            <nav>
+              <Drawer
+                variant="permanent"
+                classes={{
+                  paper: classNames(
+                    classes.navPaper,
+                    !navigationState.drawerOpen && classes.navPaperClosed
+                  )
+                }}
+                open={navigationState.drawerOpen}
+              >
+                <div className={classes.toolbar}>
+                  <IconButton
+                    aria-label="Close Drawer"
+                    onClick={() => navigationState.closeDrawer()}
+                  >
+                    <Icons.ChevronLeft />
+                  </IconButton>
+                </div>
+                <Divider />
+                <NavigationMenu />
+              </Drawer>
+            </nav>
             <main className={classes.content}>
               <div className={classes.toolbar} />
               <Switch>

--- a/src/view/Page.tsx
+++ b/src/view/Page.tsx
@@ -1,12 +1,12 @@
 import React, { ComponentType } from 'react';
-import { observer, Observer } from 'mobx-react';
 import { Route, Switch } from 'react-router-dom';
+import { observer, Observer } from 'mobx-react';
 import classNames from 'classnames';
 import AppBar from 'material-ui/AppBar';
-import Toolbar from 'material-ui/Toolbar';
-import IconButton from 'material-ui/IconButton';
 import Divider from 'material-ui/Divider';
 import Drawer from 'material-ui/Drawer';
+import IconButton from 'material-ui/IconButton';
+import Toolbar from 'material-ui/Toolbar';
 import * as Icons from '@material-ui/icons';
 import { state as navigationState } from 'state/NavigationState';
 import { createStyled } from 'view/createStyled';
@@ -18,7 +18,7 @@ import {
   SpecificationViewerToolbar
 } from 'view/SpecificationViewer';
 import { ProfileViewer, ProfileViewerToolbar } from 'view/ProfileViewer';
-import { NotFound, NotFoundToolbar } from 'basic/NotFound';
+import { NotFound, NotFoundToolbar } from 'view/basic/NotFound';
 
 // TODO: Maybe come back to this and see if we can get proper type validation going
 const Styled = createStyled(theme => {

--- a/src/view/Page.tsx
+++ b/src/view/Page.tsx
@@ -3,14 +3,12 @@ import { Route, Switch } from 'react-router-dom';
 import { observer, Observer } from 'mobx-react';
 import classNames from 'classnames';
 import AppBar from 'material-ui/AppBar';
-import Divider from 'material-ui/Divider';
-import Drawer from 'material-ui/Drawer';
 import IconButton from 'material-ui/IconButton';
 import Toolbar from 'material-ui/Toolbar';
 import * as Icons from '@material-ui/icons';
 import { state as navigationState } from 'state/NavigationState';
 import { createStyled } from 'view/createStyled';
-import { NavigationMenu } from 'view/NavigationMenu';
+import { NavigationMenu, drawerWidth } from 'view/NavigationMenu';
 import { SettingsViewer } from 'view/SettingsViewer';
 import { Overview, OverviewToolbar } from 'view/Overview';
 import {
@@ -21,71 +19,49 @@ import { ProfileViewer, ProfileViewerToolbar } from 'view/ProfileViewer';
 import { NotFound, NotFoundToolbar } from 'view/basic/NotFound';
 
 // TODO: Maybe come back to this and see if we can get proper type validation going
-const Styled = createStyled(theme => {
-  const drawerWidth = theme.spacing.unit * 28;
-  return {
-    page: {
-      display: 'flex',
-      minHeight: '100vh',
-      background: theme.palette.background.default
-    },
-    appBar: {
-      zIndex: theme.zIndex.drawer + 1,
-      transition: theme.transitions.create(['width', 'margin'], {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.leavingScreen
-      })
-    },
-    appBarShift: {
-      marginLeft: drawerWidth,
-      width: `calc(100% - ${drawerWidth}px)`,
-      transition: theme.transitions.create(['width', 'margin'], {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.enteringScreen
-      })
-    },
-    toolbar: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'flex-end',
-      paddingLeft: theme.spacing.unit,
-      paddingRight: theme.spacing.unit,
-      ...theme.mixins.toolbar
-    },
-    menuButton: {
-      marginLeft: theme.spacing.unit * 1.5,
-      marginRight: theme.spacing.unit * 2.5
-    },
-    hide: {
-      display: 'none'
-    },
-    navPaper: {
-      position: 'relative',
-      overflowX: 'hidden',
-      width: drawerWidth,
-      transition: theme.transitions.create('width', {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.enteringScreen
-      })
-    },
-    navPaperClosed: {
-      width: theme.spacing.unit * 7,
-      [theme.breakpoints.up('sm')]: {
-        width: theme.spacing.unit * 9
-      },
-      transition: theme.transitions.create('width', {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.leavingScreen
-      })
-    },
-    content: {
-      flexBasis: '600px',
-      flexGrow: 1,
-      flexShrink: 1,
-      paddingTop: 2 * theme.spacing.unit
-    }
-  };
-});
+const Styled = createStyled(theme => ({
+  page: {
+    display: 'flex',
+    minHeight: '100vh',
+    background: theme.palette.background.default
+  },
+  appBar: {
+    zIndex: theme.zIndex.drawer + 1,
+    transition: theme.transitions.create(['width', 'margin'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen
+    })
+  },
+  appBarShift: {
+    marginLeft: drawerWidth,
+    width: `calc(100% - ${drawerWidth}px)`,
+    transition: theme.transitions.create(['width', 'margin'], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen
+    })
+  },
+  toolbar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    paddingLeft: theme.spacing.unit,
+    paddingRight: theme.spacing.unit,
+    ...theme.mixins.toolbar
+  },
+  menuButton: {
+    marginLeft: theme.spacing.unit * 1.5,
+    marginRight: theme.spacing.unit * 2.5
+  },
+  hide: {
+    display: 'none'
+  },
+  content: {
+    flexBasis: '600px',
+    flexGrow: 1,
+    flexShrink: 1,
+    paddingTop: 2 * theme.spacing.unit
+  }
+}));
 
 // Page routes
 const routes = [
@@ -151,27 +127,7 @@ export const Page: ComponentType<{}> = () => (
               </Toolbar>
             </AppBar>
             <nav>
-              <Drawer
-                variant="permanent"
-                classes={{
-                  paper: classNames(
-                    classes.navPaper,
-                    !navigationState.drawerOpen && classes.navPaperClosed
-                  )
-                }}
-                open={navigationState.drawerOpen}
-              >
-                <div className={classes.toolbar}>
-                  <IconButton
-                    aria-label="Close Drawer"
-                    onClick={() => navigationState.closeDrawer()}
-                  >
-                    <Icons.ChevronLeft />
-                  </IconButton>
-                </div>
-                <Divider />
-                <NavigationMenu />
-              </Drawer>
+              <NavigationMenu />
             </nav>
             <main className={classes.content}>
               <div className={classes.toolbar} />

--- a/src/view/Page.tsx
+++ b/src/view/Page.tsx
@@ -44,6 +44,14 @@ const Styled = createStyled(theme => {
         duration: theme.transitions.duration.enteringScreen
       })
     },
+    toolbar: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'flex-end',
+      paddingLeft: theme.spacing.unit,
+      paddingRight: theme.spacing.unit,
+      ...theme.mixins.toolbar
+    },
     menuButton: {
       marginLeft: theme.spacing.unit * 1.5,
       marginRight: theme.spacing.unit * 2.5
@@ -69,14 +77,6 @@ const Styled = createStyled(theme => {
         easing: theme.transitions.easing.sharp,
         duration: theme.transitions.duration.leavingScreen
       })
-    },
-    toolbar: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'flex-end',
-      paddingLeft: theme.spacing.unit,
-      paddingRight: theme.spacing.unit,
-      ...theme.mixins.toolbar
     },
     content: {
       flexBasis: '600px',

--- a/src/view/Page.tsx
+++ b/src/view/Page.tsx
@@ -1,29 +1,119 @@
 import React, { ComponentType } from 'react';
-import { SpecificationViewer } from 'view/SpecificationViewer';
-import { Overview } from 'view/Overview';
+import { observer, Observer } from 'mobx-react';
 import { Route, Switch } from 'react-router-dom';
-import { ProfileViewer } from 'view/ProfileViewer';
+import classNames from 'classnames';
+import AppBar from 'material-ui/AppBar';
+import Toolbar from 'material-ui/Toolbar';
+import IconButton from 'material-ui/IconButton';
+import Divider from 'material-ui/Divider';
+import Drawer from 'material-ui/Drawer';
+import * as Icons from '@material-ui/icons';
+import { state as navigationState } from 'state/NavigationState';
 import { createStyled } from 'view/createStyled';
 import { NavigationMenu } from 'view/NavigationMenu';
 import { SettingsViewer } from 'view/SettingsViewer';
-import { NotFound } from 'basic/NotFound';
-import { observer } from 'mobx-react';
-const Styled = createStyled(theme => ({
-  page: {
-    display: 'flex',
-    minHeight: '100vh',
-    background: theme.palette.background.default
+import { Overview, OverviewToolbar } from 'view/Overview';
+import {
+  SpecificationViewer,
+  SpecificationViewerToolbar
+} from 'view/SpecificationViewer';
+import { ProfileViewer, ProfileViewerToolbar } from 'view/ProfileViewer';
+import { NotFound, NotFoundToolbar } from 'basic/NotFound';
+
+// TODO: Maybe come back to this and see if we can get proper type validation going
+const Styled = createStyled(theme => {
+  const drawerWidth = theme.spacing.unit * 28;
+  return {
+    page: {
+      display: 'flex',
+      minHeight: '100vh',
+      background: theme.palette.background.default
+    },
+    appBar: {
+      zIndex: theme.zIndex.drawer + 1,
+      transition: theme.transitions.create(['width', 'margin'], {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen
+      })
+    },
+    appBarShift: {
+      marginLeft: drawerWidth,
+      width: `calc(100% - ${drawerWidth}px)`,
+      transition: theme.transitions.create(['width', 'margin'], {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.enteringScreen
+      })
+    },
+    menuButton: {
+      marginLeft: theme.spacing.unit * 1.5,
+      marginRight: theme.spacing.unit * 2.5
+    },
+    hide: {
+      display: 'none'
+    },
+    navPaper: {
+      position: 'relative',
+      overflowX: 'hidden',
+      width: drawerWidth,
+      transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.enteringScreen
+      })
+    },
+    navPaperClosed: {
+      width: theme.spacing.unit * 7,
+      [theme.breakpoints.up('sm')]: {
+        width: theme.spacing.unit * 9
+      },
+      transition: theme.transitions.create('width', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen
+      })
+    },
+    toolbar: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'flex-end',
+      paddingLeft: theme.spacing.unit,
+      paddingRight: theme.spacing.unit,
+      ...theme.mixins.toolbar
+    },
+    sideBar: {
+      flexGrow: 0,
+      flexShrink: 0
+    },
+    content: {
+      flexBasis: '600px',
+      flexGrow: 1,
+      flexShrink: 1,
+      paddingTop: 2 * theme.spacing.unit
+    }
+  };
+});
+
+// Page routes
+const routes = [
+  {
+    exact: true,
+    path: '/',
+    component: Overview,
+    toolbarComponent: OverviewToolbar
   },
-  sideBar: {
-    flexGrow: 0,
-    flexShrink: 0
+  {
+    path: '/specifications/:id',
+    component: SpecificationViewer,
+    toolbarComponent: SpecificationViewerToolbar
   },
-  content: {
-    flexBasis: '600px',
-    flexGrow: 1,
-    flexShrink: 1
+  {
+    path: '/profiles/:id',
+    component: ProfileViewer,
+    toolbarComponent: ProfileViewerToolbar
+  },
+  {
+    component: NotFound,
+    toolbarComponent: NotFoundToolbar
   }
-}));
+];
 
 /**
  * The Swagger Platform page
@@ -31,22 +121,75 @@ const Styled = createStyled(theme => ({
 export const Page: ComponentType<{}> = () => (
   <Styled>
     {({ classes }) => (
-      <div className={classes.page}>
-        <aside className={classes.sideBar}>
-          <nav>
-            <NavigationMenu />
-          </nav>
-        </aside>
-        <main className={classes.content}>
-          <Switch>
-            <Route exact path="/" component={Overview} />
-            <Route path="/specifications/:id" component={SpecificationViewer} />
-            <Route path="/profiles/:id" component={ProfileViewer} />
-            <Route path="/settings" component={SettingsViewer} />
-            <Route component={NotFound} />
-          </Switch>
-        </main>
-      </div>
+      <Observer>
+        {() => (
+          <div className={classes.page}>
+            <AppBar
+              className={classNames(
+                classes.appBar,
+                navigationState.drawerOpen && classes.appBarShift
+              )}
+            >
+              <Toolbar disableGutters={!navigationState.drawerOpen}>
+                <IconButton
+                  color="inherit"
+                  aria-label="Open Drawer"
+                  onClick={() => navigationState.openDrawer()}
+                  className={classNames(
+                    classes.menuButton,
+                    navigationState.drawerOpen && classes.hide
+                  )}
+                >
+                  <Icons.Menu />
+                </IconButton>
+                <Switch>
+                  {routes.map(({ path, toolbarComponent, exact }, i) => (
+                    <Route
+                      key={i}
+                      path={path}
+                      exact={exact}
+                      component={toolbarComponent}
+                    />
+                  ))}
+                </Switch>
+              </Toolbar>
+            </AppBar>
+            <aside className={classes.sideBar}>
+              <nav>
+                <Drawer
+                  variant="permanent"
+                  classes={{
+                    paper: classNames(
+                      classes.navPaper,
+                      !navigationState.drawerOpen && classes.navPaperClosed
+                    )
+                  }}
+                  open={navigationState.drawerOpen}
+                >
+                  <div className={classes.toolbar}>
+                    <IconButton
+                      aria-label="Close Drawer"
+                      onClick={() => navigationState.closeDrawer()}
+                    >
+                      <Icons.ChevronLeft />
+                    </IconButton>
+                  </div>
+                  <Divider />
+                  <NavigationMenu />
+                </Drawer>
+              </nav>
+            </aside>
+            <main className={classes.content}>
+              <div className={classes.toolbar} />
+              <Switch>
+                {routes.map(({ path, component, exact }, i) => (
+                  <Route key={i} path={path} exact={exact} component={component} />
+                ))}
+              </Switch>
+            </main>
+          </div>
+        )}
+      </Observer>
     )}
   </Styled>
 );

--- a/src/view/ProfileViewer.tsx
+++ b/src/view/ProfileViewer.tsx
@@ -1,8 +1,10 @@
 import React, { SFC } from 'react';
 import { observer } from 'mobx-react';
+import Typography from 'material-ui/Typography';
 import { state } from 'state/ProfileState';
 import { ProfileInformation } from 'src/view/basic/ProfileInformation';
 import { ContentContainer } from 'basic/ContentContainer';
+
 // TODO: Add react-router's injected props
 export const ProfileViewer: SFC<any> = observer(() => (
   <ContentContainer>
@@ -12,3 +14,11 @@ export const ProfileViewer: SFC<any> = observer(() => (
     <ProfileInformation profile={state.me} />
   </ContentContainer>
 ));
+
+export const ProfileViewerToolbar: SFC<{}> = () => (
+  <div>
+    <Typography color="inherit" variant="title">
+      Account
+    </Typography>
+  </div>
+);

--- a/src/view/ProfileViewer.tsx
+++ b/src/view/ProfileViewer.tsx
@@ -2,8 +2,8 @@ import React, { SFC } from 'react';
 import { observer } from 'mobx-react';
 import Typography from 'material-ui/Typography';
 import { state } from 'state/ProfileState';
-import { ProfileInformation } from 'src/view/basic/ProfileInformation';
-import { ContentContainer } from 'basic/ContentContainer';
+import { ContentContainer } from 'view/basic/ContentContainer';
+import { ProfileInformation } from 'view/basic/ProfileInformation';
 
 // TODO: Add react-router's injected props
 export const ProfileViewer: SFC<any> = observer(() => (

--- a/src/view/SettingsViewer.tsx
+++ b/src/view/SettingsViewer.tsx
@@ -1,11 +1,14 @@
 import React, { ComponentType } from 'react';
 import { observer } from 'mobx-react';
-import { FormControl, FormLabel, FormControlLabel, FormGroup, Switch } from 'material-ui';
-import { ContentContainer } from 'basic/ContentContainer';
+import { FormControl, FormLabel, FormControlLabel, FormGroup } from 'material-ui/Form';
+import Switch from 'material-ui/Switch';
+import { ContentContainer } from 'view/basic/ContentContainer';
 import { state } from 'state/SettingsState';
 import { createStyled } from 'view/createStyled';
+
 const Styled = createStyled(theme => ({}));
 const darkThemeLabel = 'Dark theme';
+
 // TODO: Add react-router's injected props
 export const SettingsViewer: ComponentType<{}> = observer(() => (
   <Styled>

--- a/src/view/SpecificationViewer.tsx
+++ b/src/view/SpecificationViewer.tsx
@@ -1,9 +1,9 @@
 import React, { SFC } from 'react';
 import { observer } from 'mobx-react';
 import Typography from 'material-ui/Typography';
-import { SpecificationInformation } from 'basic/SpecificationInformation';
 import { state } from 'state/SpecificationState';
-import { ContentContainer } from 'basic/ContentContainer';
+import { ContentContainer } from 'view/basic/ContentContainer';
+import { SpecificationInformation } from 'view/basic/SpecificationInformation';
 
 // TODO: Fix the prop types for this
 export const SpecificationViewer: SFC<any> = observer(({ match }) => {

--- a/src/view/SpecificationViewer.tsx
+++ b/src/view/SpecificationViewer.tsx
@@ -1,8 +1,10 @@
 import React, { SFC } from 'react';
 import { observer } from 'mobx-react';
+import Typography from 'material-ui/Typography';
 import { SpecificationInformation } from 'basic/SpecificationInformation';
 import { state } from 'state/SpecificationState';
 import { ContentContainer } from 'basic/ContentContainer';
+
 // TODO: Fix the prop types for this
 export const SpecificationViewer: SFC<any> = observer(({ match }) => {
   const specification = state.specifications.get(match.id);
@@ -11,3 +13,11 @@ export const SpecificationViewer: SFC<any> = observer(({ match }) => {
     <SpecificationInformation specification={specification} />
   ) : null;
 });
+
+export const SpecificationViewerToolbar: SFC<{}> = () => (
+  <div>
+    <Typography color="inherit" variant="title">
+      View Specification
+    </Typography>
+  </div>
+);

--- a/src/view/ThemeProvider.tsx
+++ b/src/view/ThemeProvider.tsx
@@ -1,7 +1,8 @@
 import React, { SFC } from 'react';
-import { createMuiTheme, MuiThemeProvider } from 'material-ui';
 import { observer } from 'mobx-react';
+import { createMuiTheme, MuiThemeProvider } from 'material-ui';
 import { state } from 'state/SettingsState';
+
 export const ThemeProvider: SFC<{}> = observer(({ children }) => (
   <MuiThemeProvider
     theme={createMuiTheme({

--- a/src/view/basic/BuildStatusChip.tsx
+++ b/src/view/basic/BuildStatusChip.tsx
@@ -1,11 +1,11 @@
 import React, { SFC } from 'react';
-import { BuildStatus } from 'model/SDK';
+import Chip from 'material-ui/Chip';
 import red from 'material-ui/colors/red';
 import green from 'material-ui/colors/green';
 import amber from 'material-ui/colors/amber';
 import grey from 'material-ui/colors/grey';
+import { BuildStatus } from 'model/SDK';
 import { createStyled } from 'view/createStyled';
-import Chip from 'material-ui/Chip';
 
 const colorStatusArray = [grey[300], amber[500], green[600], red[900]];
 const statusStringArray = ['Never run', 'Running', 'Success', 'Failed'];
@@ -18,7 +18,6 @@ export interface BuildStatusChipProps extends React.DOMAttributes<HTMLDivElement
  * Very basic information about a specification.
  * For use in lists, grids, etc.
  */
-
 export const BuildStatusChip: SFC<BuildStatusChipProps> = ({ buildStatus }) => {
   const Styled: any = createStyled(theme => ({
     root: {

--- a/src/view/basic/ContentContainer.tsx
+++ b/src/view/basic/ContentContainer.tsx
@@ -1,12 +1,14 @@
 import React, { ComponentType } from 'react';
+import { observer } from 'mobx-react';
 import { createStyled } from 'view/createStyled';
 import { state } from 'state/SettingsState';
-import { observer } from 'mobx-react';
+
 const Styled = createStyled(theme => ({
   content: {
     padding: theme.spacing.unit * 2
   }
 }));
+
 export const ContentContainer: ComponentType<{}> = ({ children }) => (
   <Styled>{({ classes }) => <div className={classes.content}>{children}</div>}</Styled>
 );

--- a/src/view/basic/NotFound.tsx
+++ b/src/view/basic/NotFound.tsx
@@ -2,6 +2,7 @@ import React, { SFC } from 'react';
 import Typography from 'material-ui/Typography';
 
 export const NotFound: SFC<{}> = () => <div>Not found</div>;
+
 export const NotFoundToolbar: SFC<{}> = () => (
   <div>
     <Typography color="inherit" variant="title">

--- a/src/view/basic/NotFound.tsx
+++ b/src/view/basic/NotFound.tsx
@@ -1,2 +1,11 @@
 import React, { SFC } from 'react';
+import Typography from 'material-ui/Typography';
+
 export const NotFound: SFC<{}> = () => <div>Not found</div>;
+export const NotFoundToolbar: SFC<{}> = () => (
+  <div>
+    <Typography color="inherit" variant="title">
+      Not Found
+    </Typography>
+  </div>
+);

--- a/src/view/basic/ProfileInformation.tsx
+++ b/src/view/basic/ProfileInformation.tsx
@@ -1,5 +1,6 @@
 import React, { SFC } from 'react';
 import { Profile } from 'model/Profile';
+
 export interface ProfileInformationProps {
   readonly profile: Profile;
 }

--- a/src/view/basic/SDKItem.tsx
+++ b/src/view/basic/SDKItem.tsx
@@ -1,11 +1,11 @@
 import React, { SFC } from 'react';
-import { SDK, BuildStatus } from 'model/SDK';
-import Typography from 'material-ui/Typography';
-import { createStyled } from 'view/createStyled';
-import { BuildStatusChip } from './BuildStatusChip';
+import Button from 'material-ui/Button';
 import Grid from 'material-ui/Grid';
 import { ListItem, ListItemText } from 'material-ui/List';
-import Button from 'material-ui/Button';
+import Typography from 'material-ui/Typography';
+import { SDK, BuildStatus } from 'model/SDK';
+import { createStyled } from 'view/createStyled';
+import { BuildStatusChip } from 'view/basic/BuildStatusChip';
 
 const Styled: any = createStyled(theme => ({
   secondary: {
@@ -21,7 +21,6 @@ export interface SDKItemProps extends React.DOMAttributes<HTMLDivElement> {
  * Very basic information about a SDK.
  * For use in lists, grids, etc.
  */
-
 export const SDKItem: SFC<SDKItemProps> = ({ sdk }) => (
   <Styled>
     {({ classes }) => (

--- a/src/view/basic/SpecificationInformation.tsx
+++ b/src/view/basic/SpecificationInformation.tsx
@@ -1,8 +1,10 @@
 import React, { SFC } from 'react';
 import { Specification } from 'model/Specification';
+
 export interface SpecificationInformationProps {
   specification: Specification;
 }
+
 /**
  * Shows detailed information about a specified specification
  */

--- a/src/view/basic/SpecificationItem.tsx
+++ b/src/view/basic/SpecificationItem.tsx
@@ -1,19 +1,19 @@
 import React, { SFC } from 'react';
-import { Specification } from 'model/Specification';
+import Button from 'material-ui/Button';
+import Close from '@material-ui/icons/Close';
+import Edit from '@material-ui/icons/Edit';
 import ExpansionPanel, {
   ExpansionPanelSummary,
   ExpansionPanelDetails
 } from 'material-ui/ExpansionPanel';
-import Typography from 'material-ui/Typography';
-import { createStyled } from 'view/createStyled';
-import Info from '@material-ui/icons/InfoOutline';
-import Close from '@material-ui/icons/Close';
 import Grid from 'material-ui/Grid';
-import List, { ListItem, ListItemText, ListItemSecondaryAction } from 'material-ui/List';
-import Button from 'material-ui/Button';
 import IconButton from 'material-ui/IconButton';
-import Edit from '@material-ui/icons/Edit';
-import { SDKItem } from './SDKItem';
+import Info from '@material-ui/icons/InfoOutline';
+import List, { ListItem, ListItemText, ListItemSecondaryAction } from 'material-ui/List';
+import Typography from 'material-ui/Typography';
+import { Specification } from 'model/Specification';
+import { createStyled } from 'view/createStyled';
+import { SDKItem } from 'view/basic/SDKItem';
 
 const Styled: any = createStyled(theme => ({
   secondary: {

--- a/src/view/basic/SpecificationItem.tsx
+++ b/src/view/basic/SpecificationItem.tsx
@@ -48,7 +48,6 @@ export interface SpecificationItemProps extends React.DOMAttributes<HTMLDivEleme
  * Very basic information about a specification.
  * For use in lists, grids, etc.
  */
-
 export const SpecificationItem: SFC<SpecificationItemProps> = ({
   specification,
   expanded,

--- a/src/view/basic/SpecificationList.tsx
+++ b/src/view/basic/SpecificationList.tsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import Grid from 'material-ui/Grid';
-import { Specification } from 'model/Specification';
-import { SpecificationItem } from 'basic/SpecificationItem';
 import Typography from 'material-ui/Typography';
+import { Specification } from 'model/Specification';
+import { SpecificationItem } from 'view/basic/SpecificationItem';
 
 export interface SpecificationListProps extends React.DOMAttributes<HTMLDivElement> {
   specifications: Specification[];
@@ -14,7 +14,6 @@ export interface SpecificationListProps extends React.DOMAttributes<HTMLDivEleme
 /**
  * Lists a series of specifications
  */
-
 export class SpecificationList extends Component<SpecificationListProps> {
   render() {
     const {

--- a/src/view/createStyled.tsx
+++ b/src/view/createStyled.tsx
@@ -1,4 +1,5 @@
 import { withStyles, withTheme } from 'material-ui';
+
 /**
  * Alternative to withStyles that doesn't use HOCs
  * @see https://material-ui-next.com/customization/css-in-js/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,6 @@ module.exports = (env, argv) => {
         config: paths.config,
         view: paths.view,
         model: paths.model,
-        basic: paths.basic,
         state: paths.state,
         client: paths.client,
         backend: paths.backend,


### PR DESCRIPTION
Did this as it's going to be needed to add action buttons (like an 'Add' button on the Overview page). Had to refactor the Page and NavigationMenu components quite a bit in the process.

I've designed this so that we can specify our own toolbar component for each route, meaning its completely customisable between pages.

I've based this off GH-13, can rebase it off development after GH-13 is merged.