### PR TITLE
Fixed jest test file transpilation

### DIFF
--- a/backend.transform.js
+++ b/backend.transform.js
@@ -1,0 +1,11 @@
+const createWebpackConfig = require('./webpack.config');
+const webpackConfig = createWebpackConfig(process.env, process.argv);
+const backendConfig = webpackConfig.filter(({ name }) => name === 'Backend')[0];
+const babelConfig = backendConfig.module.rules.filter(
+  ({ loader }) => loader === 'babel-loader',
+)[0];
+const babelOptions = babelConfig.options;
+
+const babelJest = require('babel-jest');
+
+module.exports = babelJest.createTransformer(babelOptions);

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,6 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   transform: {
-    '^.+\\.tsx?$': 'babel-jest',
+    '^.+\\.tsx?$': './backend.transform.js',
   },
 };


### PR DESCRIPTION
babel-jest didn't have a .babelrc file so it couldn't transpile properly.
I fixed that: Had to pull the babel configuration from the webpack file which seems a little weird but i'd rather be able to write tests than none at all.