### PR TITLE
Fix nodemon not running correctly with spaces in the filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
     "webpack": "4.1.1",
     "webpack-cli": "2.0.12",
     "webpack-dev-server": "3.1.1",
-    "webpack-node-externals": "1.6.0",
-    "webpack-shell-plugin": "0.5.0"
+    "webpack-node-externals": "1.6.0"
   },
   "dependencies": {
     "@feathersjs/client": "3.4.5",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "babel-loader": "8.0.0-beta.2",
     "babel-plugin-module-resolver": "3.1.1",
     "babel-runtime": "7.0.0-beta.3",
+    "cross-spawn": "6.0.5",
     "css-loader": "0.28.11",
     "file-loader": "1.1.11",
     "html-webpack-plugin": "3.0.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 module.exports = (env, argv) => {
   const paths = require('./paths');
   const { join } = require('path');
-  const { spawn } = require('child_process');
+  const { spawn } = require('cross-spawn');
   const HtmlWebpackPlugin = require('html-webpack-plugin');
   const { HotModuleReplacementPlugin } = require('webpack');
   const nodeExternals = require('webpack-node-externals');
@@ -89,8 +89,7 @@ module.exports = (env, argv) => {
         compiler.hooks.afterEmit.tap('AfterBuildPlugin', compilation => {
           console.log('Rebuilding backend...');
           if (firstBuild) {
-            const nodemon = spawn('npx', [
-              'nodemon',
+            const nodemon = spawn('nodemon', [
               backendIndex,
               '--quiet',
               '--watch',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,8 @@ module.exports = (env, argv) => {
         compiler.hooks.afterEmit.tap('AfterBuildPlugin', compilation => {
           console.log('Rebuilding backend...');
           if (firstBuild) {
-            const nodemon = spawn('nodemon', [
+            const nodemon = spawn('npx', [
+              'nodemon',
               backendIndex,
               '--quiet',
               '--watch',


### PR DESCRIPTION
webpack-shell-plugin did not allow us to pass in arguments to nodemon separately to the shell command, meaning certain special characters in arguments would not be passed correctly. In addition, webpack-shell-plugin was causing the ``DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead`` message to be displayed each build too.

This fixes both issues by launching nodemon using Node's `child_process.spawn()` function instead of relying on webpack-shell-plugin. 